### PR TITLE
Quote URL parameter when used with background-image css style

### DIFF
--- a/src/sprite-thumbnails.js
+++ b/src/sprite-thumbnails.js
@@ -70,7 +70,7 @@ const spriteThumbs = (player, plugin, options) => {
       const tooltipStyle = {
         'width': scaledWidth + 'px',
         'height': scaledHeight + 'px',
-        'background-image': 'url(' + url + ')',
+        'background-image': 'url("' + url + '")',
         'background-repeat': 'no-repeat',
         'background-position': cleft + 'px ' + ctop + 'px',
         'background-size': bgSize,


### PR DESCRIPTION
I have a few sprites which had some spaces in the URL, although they would load via the `<img>` tag, the actual thumbnail wouldn't show. This appears to be because of the spaces in the URLs.

Simply quoting the string was enough to resolve the issue.