### PR TITLE
Add support for multiple sprites

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -27,7 +27,8 @@ const defaults = {
   height: 0,
   interval: 1,
   responsive: 600,
-  downlink: 1.5
+  downlink: 1.5,
+  urls: []
 };
 
 /**

--- a/src/sprite-thumbnails.js
+++ b/src/sprite-thumbnails.js
@@ -57,7 +57,7 @@ const spriteThumbs = (player, plugin, options) => {
     if (!(sprite && sprite.complete)) {
       return;
     }
-    framesInEachUrl = Math.ceil(imgWidth / width) * Math.ceil(imgHeight / height);
+    framesInEachUrl = Math.round((imgWidth / width) * (imgHeight / height));
     secondsForEachUrl = framesInEachUrl * options.interval;
   };
 


### PR DESCRIPTION
Using a single sprite for a huge video is not going to work, either we need to increase interval and loose on number of thumbs per 30 seconds or we create a huge sprite taking all of the memory

Creating multiple sprites will help deal with this issue

Please feel free to make naming / logic improvements